### PR TITLE
Fix auto-closing door config option, and make iron doors behave more like vanilla

### DIFF
--- a/src/main/java/de/jeff_media/doorsreloaded/listeners/DoorListener.java
+++ b/src/main/java/de/jeff_media/doorsreloaded/listeners/DoorListener.java
@@ -89,6 +89,7 @@ public class DoorListener implements Listener {
     public void onIronDoor(PlayerInteractEvent event) {
         if(event.getHand() != EquipmentSlot.HAND) return;
         if(event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+        if(event.getPlayer().isSneaking() && event.hasItem()) return; // Vanilla doors do not open if sneaking while holding an item
         Block block = event.getClickedBlock();
         if(block.getType() != Material.IRON_DOOR && block.getType() != Material.IRON_TRAPDOOR) return;
         if(!main.getConfig().getBoolean(Config.ALLOW_IRONDOORS)) return;
@@ -98,6 +99,8 @@ public class DoorListener implements Listener {
         door.setOpen(!door.isOpen());
         onRightClickDoor(event);
         block.setBlockData(door);
+
+        if (!main.getConfig().getBoolean(Config.ALLOW_AUTOCLOSE)) return;
         autoClose.put(block,System.currentTimeMillis() + (main.getConfig().getLong("autoclose")*1000));
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,10 @@ check-for-redstone: true
 # They need the permission "doorsreloaded.irondoors".
 allow-opening-irondoors-with-hands: false
 
+# When true, iron doors/trapdoors will be automatically closed when they are opened with right-click.
+# The amount of time before they close can be configured below.
+allow-autoclose: false
+
 # Time to autoclose iron doors/trapdoors in seconds
 autoclose: 5
 


### PR DESCRIPTION
Only queue iron door to be auto-closed if the config file says we should. Add a default `false` to the config since that's the current behavior.

Do not open iron doors if the player is sneaking AND has an item in their hand, as vanilla wooden doors would not open in this case.